### PR TITLE
fix(login): stop comment-token expansion breaking the login page [skip-screenshot]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.1.3](https://github.com/iFadi/LUH-Skin/compare/v2.1.2...v2.1.3) (2026-07-02)
+
+### Bug Fixes
+
+* **login:** stop the login page from leaking raw markup and a duplicated "Login mit
+  WebSSO". The explanatory HTML comment contained the `{SHIB_LOGIN_FORM}` token;
+  ILIAS expands template tokens even inside comments, and the injected Shibboleth
+  form (which itself contains `-->`) terminated the comment early. Reworded the
+  comment so it no longer contains the token.
+
+
 ## [2.1.2](https://github.com/iFadi/LUH-Skin/compare/v2.1.1...v2.1.2) (2026-07-02)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Dieser Skin wurde dem [LUH-Stil](https://www.uni-hannover.de/) entsprechend ange
 ---
 
 ## Version
-v2.1.2 — für **ILIAS 10**
+v2.1.3 — für **ILIAS 10**
 
 > Der ILIAS-9-Stand bleibt auf den `v1.x`-Tags erhalten (zuletzt `v1.3.0`).
 
@@ -51,7 +51,7 @@ cd LUH-Skin
 Beispiel für einen stabilen Release-Tag:
 
 ```bash
-git checkout tags/v2.1.2
+git checkout tags/v2.1.3
 ```
 
 Falls du dich auf dem `main`-Branch befindest, kannst du einfach ein Pull durchführen:

--- a/components/ILIAS/Init/tpl.login.html
+++ b/components/ILIAS/Init/tpl.login.html
@@ -17,10 +17,12 @@
                 <section class="luh-col luh-col-main">
                     <h2 class="luh-uni-title">Leibniz Universität Hannover</h2>
 
-                    <!-- WebSSO login (rendered by ILIAS when Shibboleth is active) -->
-                    <!-- {SHIB_LOGIN_FORM} carries both the "Login mit WebSSO" link and its
-                         "für Angehörige der LUH" subtitle (see tpl.login_form_shibboleth.html),
-                         so both appear only when Shibboleth/WebSSO is actually active. -->
+                    <!-- WebSSO login. ILIAS injects the WebSSO login form at the placeholder
+                         below; it carries both the "Login mit WebSSO" link and its "für
+                         Angehörige der LUH" subtitle (see tpl.login_form_shibboleth.html), so
+                         both appear only when Shibboleth/WebSSO is active. NOTE: do not write
+                         the placeholder's {…} token inside an HTML comment — ILIAS expands it
+                         even there, and the injected markup breaks the comment. -->
                     <div class="luh-login-option" id="shib-form-login-mask">
                         {SHIB_LOGIN_FORM}
                     </div>


### PR DESCRIPTION
### Problem
On a Shibboleth-active server the login page showed a **duplicated "Login mit WebSSO"** and **leaked comment text** ("carries both … -->").

### Cause
The explanatory HTML comment in `tpl.login.html` contained the literal `{SHIB_LOGIN_FORM}` token. ILIAS expands `{…}` tokens **even inside HTML comments**, so the Shibboleth form was injected into the comment; that form markup contains its own `-->`, which terminated the comment early and dumped the rest onto the page.

### Fix
Reworded the comment so it no longer contains any `{…}` token. No SCSS/visual change — the rendered result now matches the existing README screenshot, hence `[skip-screenshot]`.

Ships as **v2.1.3** (README + CHANGELOG bumped).